### PR TITLE
loire: Mount Qnovo partition as vendor

### DIFF
--- a/rootdir/vendor/etc/fstab.loire
+++ b/rootdir/vendor/etc/fstab.loire
@@ -4,6 +4,7 @@
 
 /dev/block/platform/soc/7824900.sdhci/by-name/system       /system      ext4    ro,barrier=1                                                  wait,first_stage_mount
 /dev/block/platform/soc/7824900.sdhci/by-name/oem          /odm         ext4    ro,barrier=1                                                  wait,first_stage_mount
+/dev/block/platform/soc/7824900.sdhci/by-name/Qnovo        /cache       ext4    noatime,nosuid,nodev,barrier=1,data=ordered,noauto_da_alloc,errors=panic wait,check,formattable
 /dev/block/platform/soc/7824900.sdhci/by-name/cache        /vendor       ext4    ro,noatime wait,check,first_stage_mount
 /dev/block/platform/soc/7824900.sdhci/by-name/userdata     /data        ext4    noatime,nosuid,nodev,barrier=1,data=ordered,noauto_da_alloc,errors=panic wait,check,formattable
 /dev/block/platform/soc/7824900.sdhci/by-name/boot         /boot        emmc    defaults                                                      defaults

--- a/sepolicy_platform/file_contexts
+++ b/sepolicy_platform/file_contexts
@@ -35,6 +35,9 @@
 /dev/block/platform/soc/7824900\.sdhci/by-name/FOTAKernel      u:object_r:recovery_block_device:s0
 /dev/block/bootdevice/by-name/FOTAKernel                       u:object_r:recovery_block_device:s0
 
+/dev/block/platform/soc/7824900\.sdhci/by-name/Qnovo           u:object_r:cache_block_device:s0
+/dev/block/bootdevice/by-name/Qnovo                            u:object_r:cache_block_device:s0
+
 /dev/block/platform/soc/7824900\.sdhci/by-name/cache           u:object_r:system_block_device:s0
 /dev/block/bootdevice/by-name/cache                            u:object_r:system_block_device:s0
 


### PR DESCRIPTION
Although we could boot without cache partition, but some Apps like Magisk will store its log in cache partition, so it is better to mount it to avoid crash.

 SODP doesn't use Qnovo for charge and this is a partition is useless. It is about 16MB so enough for log.

We don't have `qns` in oem for Qnovo:
```
sjll@sjll:~/download/odm/bin$ ls
adsprpcd        imsdatadaemon     msm_irqbalance  qmuxd        sensors.qcom
cdsprpcd        imsqmidaemon      netmgrd         qseecomd     ta_qmi_service
cnss-daemon     irsc_util         pm-proxy        rmt_storage  tad_static
ims_rtp_daemon  mlog_qmi_service  pm-service      sct_service  tftp_server
```